### PR TITLE
Simplify the API to be used in the Transfer Contract

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,39 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 pub mod types;
-pub use types::{Note, NotesBuffer, Nullifier, NullifiersBuffer};
+
+pub use types::{Note, Nullifier};
 
 mod external {
-    use super::*;
     extern "C" {
-        pub fn phoenix_store(nullifiers: &NullifiersBuffer, notes: &NotesBuffer) -> bool;
+        pub fn phoenix_store(nullifiers: *const u8, notes: *const u8) -> bool;
 
-        pub fn phoenix_verify(nullifiers: &NullifiersBuffer, notes: &NotesBuffer) -> bool;
+        pub fn phoenix_verify(nullifiers: *const u8, notes: *const u8) -> bool;
     }
 }
 
 // TODO: fix proof
-pub fn store(nullifiers: &NullifiersBuffer, notes: &NotesBuffer) -> bool {
-    unsafe { external::phoenix_store(&nullifiers, &notes) }
+pub fn store(
+    nullifiers: &[Nullifier; Nullifier::MAX],
+    notes: &[Note; Note::MAX],
+) -> bool {
+    let nullifiers_buf =
+        Nullifier::encode(nullifiers).expect("buffer insufficient");
+    let notes_buf = Note::encode(notes).expect("buffer insufficient");
+
+    unsafe {
+        external::phoenix_store(nullifiers_buf.as_ptr(), notes_buf.as_ptr())
+    }
 }
 
-pub fn verify(nullifiers: &NullifiersBuffer, notes: &NotesBuffer) -> bool {
-    unsafe { external::phoenix_verify(&nullifiers, &notes) }
+pub fn verify(
+    nullifiers: &[Nullifier; Nullifier::MAX],
+    notes: &[Note; Note::MAX],
+) -> bool {
+    let nullifiers_buf =
+        Nullifier::encode(nullifiers).expect("buffer insufficient");
+    let notes_buf = Note::encode(notes).expect("buffer insufficient");
+
+    unsafe {
+        external::phoenix_verify(nullifiers_buf.as_ptr(), notes_buf.as_ptr())
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,18 +1,9 @@
 // pub use plonk_abi::Proof;
+use fermion::{self, Error};
 use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-pub const NOTE_SIZE: usize = 273; // See `Note`
-pub const NULLIFIER_SIZE: usize = 32;
-
 // TODO: this should come from `plonk_abi`
 // pub const PROOF_SIZE: usize = 600;
-
-pub const MAX_NOTES_PER_TRANSACTION: usize = 10;
-pub const MAX_NULLIFIERS_PER_TRANSACTION: usize = 8;
-
-pub type NullifiersBuffer = [u8; MAX_NULLIFIERS_PER_TRANSACTION * NULLIFIER_SIZE];
-pub type NotesBuffer = [u8; MAX_NOTES_PER_TRANSACTION * NOTE_SIZE];
 
 #[derive(Clone, Copy)]
 struct RistrettoPointBytes([u8; 64]);
@@ -56,10 +47,10 @@ impl<'de> Deserialize<'de> for RistrettoPointBytes {
                 A: serde::de::SeqAccess<'de>,
             {
                 let mut bytes = [0u8; 64];
-                for i in 0..64 {
-                    bytes[i] = seq
+                for (i, byte) in bytes.iter_mut().enumerate() {
+                    *byte = seq
                         .next_element()?
-                        .ok_or(serde::de::Error::invalid_length(i, &"expected 64 bytes"))?;
+                        .ok_or_else(|| serde::de::Error::invalid_length(i, &"expected 64 bytes"))?;
                 }
 
                 Ok(RistrettoPointBytes(bytes))
@@ -118,10 +109,10 @@ impl<'de> Deserialize<'de> for BlindingFactorBytes {
                 A: serde::de::SeqAccess<'de>,
             {
                 let mut bytes = [0u8; 48];
-                for i in 0..48 {
-                    bytes[i] = seq
+                for (i, byte) in bytes.iter_mut().enumerate() {
+                    *byte = seq
                         .next_element()?
-                        .ok_or(serde::de::Error::invalid_length(i, &"expected 48 bytes"))?;
+                        .ok_or_else(|| serde::de::Error::invalid_length(i, &"expected 48 bytes"))?;
                 }
 
                 Ok(BlindingFactorBytes(bytes))
@@ -151,6 +142,20 @@ pub struct Note {
     encrypted_blinding_factor: BlindingFactorBytes,
 }
 
+impl Note {
+    pub const MAX: usize = 10;
+    pub const SIZE: usize = 273;
+
+    // TODO: move this method as default implementation in a common trait for
+    // `Note` and `Nullifier` once the following issue is fixed:
+    // https://github.com/rust-lang/rust/issues/43408
+    pub fn encode<T: Serialize>(t: &T) -> Result<[u8; Self::MAX * Self::SIZE], Error> {
+        let mut buffer = [0u8; Self::MAX * Self::SIZE];
+        fermion::encode(t, &mut buffer)?;
+        Ok(buffer)
+    }
+}
+
 impl core::fmt::Debug for Note {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "a")
@@ -158,7 +163,21 @@ impl core::fmt::Debug for Note {
 }
 
 #[derive(Clone, Copy, Default, Serialize, Deserialize, Debug)]
-pub struct Nullifier([u8; NULLIFIER_SIZE]);
+pub struct Nullifier([u8; Nullifier::SIZE]);
+
+impl Nullifier {
+    pub const MAX: usize = 8;
+    pub const SIZE: usize = 32;
+
+    // TODO: move this method as default implementation in a common trait for
+    // `Note` and `Nullifier` once the following issue is fixed:
+    // https://github.com/rust-lang/rust/issues/43408
+    pub fn encode<T: Serialize>(t: &T) -> Result<[u8; Self::MAX * Self::SIZE], Error> {
+        let mut buffer = [0u8; Self::MAX * Self::SIZE];
+        fermion::encode(t, &mut buffer)?;
+        Ok(buffer)
+    }
+}
 
 #[cfg(feature = "std")]
 mod convert {


### PR DESCRIPTION
- Add constants to `Note` and `Nullifier` instead of export them from
  the lib.
  Currently kept `SIZE` manually instead of using `size_of` that can have
  unpredictable behavior based on the primitive types of the struct

- Add an `encode` method to `Note` and `Nullifier`

- Apply suggestion from clippy

Resolves: #14